### PR TITLE
Await SSH tunnel init using docker exec + exit code

### DIFF
--- a/docker_push_ssh/cli.py
+++ b/docker_push_ssh/cli.py
@@ -37,12 +37,16 @@ def waitForSshTunnelInit(retries=20, delay=1.0):
     for _ in range(retries):
         time.sleep(delay)
 
-        try:
-            response = urllib2.urlopen("http://localhost:5000/v2/", timeout=5)
-        except (socket.error, urllib2.URLError):
-            continue
-
-        if response.getcode() == 200:
+        sshCheckCommandResult = Command("docker", [
+            "exec",
+            "docker-push-ssh-tunnel",
+            "wget",
+            "-O", "/dev/null",
+            "-q",
+            "http://localhost:5000/v2"
+        ]).environment_dict(os.environ).execute()
+        
+        if not sshCheckCommandResult.failed():
             return True
 
     return False


### PR DESCRIPTION
Waiting for the SSH tunnel to be ready should take place in the docker-push-ssh-tunnel container and not the host. This fixes issues where the calling container is unable to reach the registry but the tunnel container is, because the tunnel is established through that container.